### PR TITLE
docs(licensing): align BSL policy and trademark naming

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -10,13 +10,14 @@ The repository is intended to be:
 - usable for personal internal use
 - usable for internal organizational use, including inside companies
 
-The repository is not intended to authorize third-party commercial
-monetization of repository materials, the documented operating model, official
-branding, or official positioning by default.
+The repository is licensed under Business Source License 1.1. Non-production
+use is allowed by default. Limited internal production use is allowed only to
+the extent stated in the Additional Use Grant in [LICENSE](./LICENSE).
 
 ## Uses That Require Written Permission
 
-The following uses require explicit written permission from the author:
+The following uses require explicit written permission from the author before
+the Change Date when they are not otherwise permitted by [LICENSE](./LICENSE):
 
 - paid training based on the Repository or documented operating model
 - paid consulting or implementation services marketed primarily on top of the
@@ -31,23 +32,24 @@ The following uses require explicit written permission from the author:
 
 ## Internal Company Use
 
-Internal company use is intended to be allowed by default, provided that:
+Internal company use is allowed, provided that:
 
 - the repository is used internally
-- Repository materials are not commercially redistributed
-- the documented operating model is not re-marketed as a third-party product or
-  service
+- production use stays within the Additional Use Grant
+- Repository materials are not used as an external commercial offering before
+  the Change Date
 - attribution and applicable licensing terms are preserved
 
 ## Contact Path
 
 If you want to use the repository in a commercial offering, training program,
-consulting engagement, managed service, or other monetized delivery model,
-seek written permission from the author before proceeding.
+consulting engagement, managed service, embedded commercial product, or other
+monetized delivery model before the Change Date, seek written permission from
+the author before proceeding.
 
-This policy governs commercial use expectations for the Repository, the
-documented operating model, official branding, and official project
-positioning.
+This policy explains the commercial boundary alongside the BSL terms. The
+canonical legal terms, including the Additional Use Grant, Change Date, and
+Change License, are in [LICENSE](./LICENSE).
 
 ## Relationship To Other Policies
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,119 +1,88 @@
-Boring Admin Reference License 1.0
+Business Source License 1.1
 
-Copyright (c) 2026 gehorak
+License text copyright (c) 2024 MariaDB plc, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB plc.
 
-1. Purpose
+--------------------------------------------------------------------------
+Licensor:             gehorak
+Licensed Work:        boring-admin-windows repository, including all files,
+                      materials, documentation, scripts, text, configuration,
+                      and related content made available in this repository,
+                      unless a specific file expressly states otherwise.
+Additional Use Grant: Production use is permitted solely for the internal
+                      operations of a single individual or a single legal
+                      entity. This Additional Use Grant does not permit
+                      offering the Licensed Work, or a derivative or modified
+                      version of it, to third parties as a hosted service,
+                      managed service, subscription service, paid training,
+                      paid consulting, paid implementation, OEM or embedded
+                      commercial offering, support offering, or other external
+                      commercial product or service without separate written
+                      permission from the Licensor.
+Change Date:          2031-01-01
+Change License:       GPL-2.0-or-later
+--------------------------------------------------------------------------
 
-This repository is made available as a reference repository for study,
-evaluation, internal use, and controlled adoption of the documented operating
-model and related implementation materials.
+Terms
 
-2. Definitions
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
-`Repository` means all files, materials, documentation, scripts, text,
-configuration, and related content made available in this repository, unless a
-specific file expressly states otherwise.
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph above
+terminate.
 
-`Internal Use` means use by an individual person, or within a single legal
-entity or organization, for that person's or organization's own internal
-operations, evaluation, learning, administration, or implementation, without
-public redistribution or external commercialization.
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-`Commercial Use` means use primarily intended for commercial advantage,
-monetary compensation, sale, licensing revenue, paid services, subscription
-revenue, managed-service revenue, consulting fees, implementation fees,
-training fees, resale, or other monetized exploitation.
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-`Public Distribution` means making the Repository, or any modified or derived
-version of it, available to the public or to third parties outside the user's
-own organization, whether by publication, hosting, transfer, sale, licensing,
-distribution, or other disclosure.
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set forth in this License
+apply to your use of that work.
 
-`Derivative` means any modified, adapted, translated, transformed, extended,
-reorganized, repackaged, or substantially re-expressed version of the
-Repository or a substantial part of it.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-3. License Grant
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-Subject to the terms of this License, the author grants you a limited,
-non-exclusive, non-transferable, non-sublicensable license to:
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
 
-- access, read, and copy the Repository
-- use the Repository for personal Internal Use
-- use the Repository within your organization for Internal Use
-- modify the Repository for Internal Use only
-- share unmodified copies of the Repository for non-commercial reference
-  purposes, provided that all copyright, attribution, and license notices are
-  preserved
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
 
-4. Conditions
+Covenants of Licensor
 
-You must preserve:
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-- the author's name
-- copyright notices
-- this License
-- any applicable notices relating to naming, branding, trademark, and
-  commercial permissions
-
-5. Restrictions
-
-Without the author's prior written permission, you may not:
-
-- engage in Commercial Use of the Repository
-- Publicly Distribute any Derivative of the Repository
-- publish, promote, distribute, or host a fork, substitute, competing, or
-  successor public version of the Repository or its documented operating model
-- sell, sublicense, relicense, resell, package, or otherwise monetize the
-  Repository or any substantial part of it
-- provide paid training, paid consulting, paid implementation, managed
-  services, hosted services, subscription services, or other paid offerings
-  based primarily on the Repository or its documented operating model
-- remove, obscure, falsify, or misrepresent authorship, origin, or ownership
-- represent any fork, Derivative, adaptation, service, or package as official,
-  endorsed, certified, or authorized by the author
-- use the Repository in any way that conflicts with the separate naming,
-  trademark, branding, or commercial-use policies published by the author
-
-6. No Public Derivative Right
-
-This License permits internal modification for Internal Use, but does not grant
-any right to Publicly Distribute modified or derived versions of the Repository
-without prior written permission from the author.
-
-7. Commercial Licensing
-
-Commercial rights in the Repository may be granted only by separate written
-agreement with the author. No Commercial Use right is granted by this License.
-
-8. Trademarks, Naming, And Branding
-
-This License does not grant any right to use any trademark, trade name, brand,
-logo, project identity, or official-status claim of the author, except as
-necessary for truthful factual reference. Any such use remains subject to the
-author's separate naming, branding, and trademark policies.
-
-9. Termination
-
-This License terminates automatically if you breach any of its terms. Upon
-termination, you must cease all use of the Repository except to the extent that
-continued possession of lawfully retained internal archival copies is required
-by law or internal compliance obligations.
-
-10. No Warranty
-
-THE REPOSITORY IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
-
-11. Limitation Of Liability
-
-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE AUTHOR
-BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE
-REPOSITORY OR THE USE OF THE REPOSITORY.
-
-12. Entire License
-
-This License states the default permission model for the Repository unless a
-specific file or separate written agreement expressly provides otherwise.
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License
+   can be included in a program with software provided under GPL Version 2.0
+   or a later version. Licensor may specify additional Change Licenses without
+   limitation.
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+3. To specify a Change Date.
+4. Not to modify this License in any other way.

--- a/LICENSE-SUMMARY.md
+++ b/LICENSE-SUMMARY.md
@@ -14,23 +14,22 @@ Authoritative documents:
 You may:
 
 - read and evaluate the repository
-- use the Repository internally inside your organization
-- adapt Repository materials for internal use only
+- copy, modify, and redistribute the Repository
+- use the Repository in non-production environments
+- use the Repository in production for internal operations of a single
+  individual or a single legal entity within the Additional Use Grant
 - keep internal modified copies for your own internal operations
-- share unmodified copies for non-commercial reference use with attribution
 
 ## What You May Not Do Without Written Permission
 
 You may not:
 
-- publish a public modified version of the Repository
-- publish a fork or substitute public version of the Repository
-- sell or package the Repository as your own product
-- offer paid training based primarily on the Repository or its documented
-  operating model
-- offer paid consulting or implementation services marketed primarily on the
-  Repository or its documented operating model
-- commercially redistribute Repository materials
+- make production use outside the Additional Use Grant before the Change Date
+- offer the Repository, or a derivative or modified version of it, to third
+  parties as a hosted service, managed service, subscription service, OEM or
+  embedded commercial offering, support offering, paid training, paid
+  consulting, or paid implementation offering before the Change Date unless
+  separately licensed
 - present a derivative, fork, service, or package as official
 - use the project name, branding, or official-status claims in a misleading way
 
@@ -39,32 +38,48 @@ You may not:
 Internal company use is allowed when:
 
 - use stays inside your organization
-- modified Repository materials stay internal
+- production use stays within the Additional Use Grant
 - attribution and license notices are preserved
-- the Repository is not re-marketed as your own external product or service
+- external commercial offering rights are not claimed before the Change Date
 
-## Important Distinction
+## Important BSL Terms
 
 The Repository uses a single licensing model:
 
-- [Boring Admin Reference License 1.0](./LICENSE)
+- [Business Source License 1.1](./LICENSE)
+
+- non-production use is allowed by the license
+- limited internal production use is allowed by the Additional Use Grant
+- broader production use requires a separate commercial agreement until the
+  Change Date
+- each specific version converts on the earlier of:
+  - the Change Date stated in [LICENSE](./LICENSE)
+  - the fourth anniversary of that version's first public distribution
+- when a specific version converts, that version becomes available under the
+  Change License stated in [LICENSE](./LICENSE)
+
+Current parameters:
+
+- `Change Date: 2031-01-01`
+- `Change License: GPL-2.0-or-later`
 
 ## When To Contact The Author
 
 Contact the author before proceeding if you want to:
 
-- run paid training
-- sell consulting or implementation services based on the model
+- provide an external commercial offering based on the Repository
+- run paid training, paid consulting, paid implementation, or paid support
+- make production use outside the Additional Use Grant
 - package the Repository into a managed service, subscription, or commercial
   offer
-- publish a public derivative of the Repository
 - request official partner, official support, or official branding rights
 
 ## Short Practical Rule
 
-Internal use: yes.
+Internal and non-production use: yes.
 
-Public derivative distribution: no.
+External commercial offering before the Change Date: no, unless separately
+licensed.
 
-Commercial monetization of the Repository: only with written permission from
-the author.
+Later open-license conversion: automatic for each version on the earlier of the
+stated Change Date or that version's fourth public-distribution anniversary.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,12 +1,23 @@
 # Trademark And Naming Policy
 
+This document defines
+the umbrella-brand policy
+for the `boring-admin` project family.
+
 This policy applies to this repository.
 
-## Protected Project Identifiers
+In this repository,
+`boring-admin-windows`
+is a project within
+the `boring-admin` family.
+
+## Protected Brand And Project Identifiers
 
 The following identifiers are reserved by the project owner unless explicit
 written permission is granted:
 
+- `boring-admin`
+- `Boring Admin`
 - `boring-admin-windows`
 - `Boring Admin Windows`
 - any logo, badge, or visual identity later designated as official
@@ -16,7 +27,7 @@ written permission is granted:
 
 You may:
 
-- reference the project by name when accurately describing it
+- reference the brand or project by name when accurately describing it
 - link to the project
 - state factual compatibility claims if they are truthful and not misleading
 - maintain a private internal fork for your own use, subject to the applicable
@@ -26,13 +37,14 @@ You may:
 
 You may not:
 
+- market a derivative as `boring-admin`
 - market a derivative as `boring-admin-windows`
 - present a fork, service, package, or adaptation as official
 - imply endorsement, sponsorship, certification, or partnership
-- use the project name or branding in a way that creates confusion about source
+- use the brand or project naming in a way that creates confusion about source
   or ownership
 - sell services, products, packages, templates, or operating-model derivatives
-  under the project name
+  under the protected project or umbrella brand name
 
 ## Derivatives And Forks
 
@@ -44,6 +56,20 @@ Recommended practice for forks:
 - use a clearly distinct name
 - identify your fork as unofficial
 - avoid reuse of official branding
+
+## Umbrella Brand Rule
+
+The `boring-admin` name
+is treated as the primary umbrella brand.
+
+Repository-specific names,
+including `boring-admin-windows`,
+are protected as project identifiers
+within that brand family.
+
+Truthful factual references
+and truthful compatibility descriptions
+remain allowed.
 
 ## Reservation Of Rights
 


### PR DESCRIPTION
Context:
- step: STEP-LICENSE-BSL
- target: normalize repository licensing surface after BSL 1.1 adoption
- layer: docs

Implemented scope:
- replace prior reference license with BSL 1.1 in LICENSE
- align LICENSE-SUMMARY.md with BSL production and conversion semantics
- align COMMERCIAL.md with canonical BSL wording and boundaries
- fix transferred trademark naming to boring-admin-windows

Key design decisions:
- keep LICENSE as the sole canonical legal text
- use summary and commercial docs as explanatory layers only
- preserve umbrella brand boring-admin while binding this repository to boring-admin-windows
- describe version conversion using the earlier of Change Date or version-specific fourth anniversary

Model / API / behavior details:
- Licensed Work remains the full repository unless a file states otherwise
- Additional Use Grant permits internal production use for a single individual or single legal entity
- external commercial offering language remains permission-gated before the Change Date unless otherwise permitted by LICENSE
- trademark policy now protects boring-admin-windows instead of the transferred boring-admin-ai-rail identifier

Files added:
- none

Files updated:
- LICENSE
- LICENSE-SUMMARY.md
- COMMERCIAL.md
- TRADEMARKS.md

Files intentionally NOT touched:
- README.md
- docs/
- scripts/
- tests/
- .vscode/
- docs/regional/

Validation:
- manual diff review completed
- BSL field consistency checked across LICENSE, LICENSE-SUMMARY.md, and COMMERCIAL.md
- trademark naming checked against repository identity in README.md
- no automated tests run; docs-only legal-text change

Intentional exclusions:
- no Change License strategy changes
- no README licensing section rewrite
- no broader repository normalization edits

Why this commit is limited:
- the scope is intentionally restricted to the licensing surface so the legal-model change remains reviewable in isolation
- unrelated documentation and untracked working-tree content were left out on purpose

AI-Task: STEP-LICENSE-BSL
Scope: LICENSE, LICENSE-SUMMARY.md, COMMERCIAL.md, TRADEMARKS.md only
Docs: LICENSE, LICENSE-SUMMARY.md, COMMERCIAL.md, TRADEMARKS.md, README.md